### PR TITLE
Expands python34 unit tests list

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -1696,12 +1696,12 @@ class ComputeManager(manager.Manager):
         if update_root_bdm:
             root_bdm.save()
 
-        ephemerals = filter(block_device.new_format_is_ephemeral,
-                            block_devices)
-        swap = filter(block_device.new_format_is_swap,
-                      block_devices)
-        block_device_mapping = filter(
-              driver_block_device.is_block_device_mapping, block_devices)
+        ephemerals = list(filter(block_device.new_format_is_ephemeral,
+                            block_devices))
+        swap = list(filter(block_device.new_format_is_swap,
+                      block_devices))
+        block_device_mapping = list(filter(
+              driver_block_device.is_block_device_mapping, block_devices))
 
         self._default_device_names_for_instance(instance,
                                                 root_device_name,
@@ -4366,6 +4366,10 @@ class ComputeManager(manager.Manager):
                   instance=instance)
         output = self.driver.get_console_output(context, instance)
 
+        if type(output) is six.text_type:
+            # the console output will be bytes.
+            output = six.b(output)
+
         if tail_length is not None:
             output = self._tail_log(output, tail_length)
 
@@ -4378,9 +4382,9 @@ class ComputeManager(manager.Manager):
             length = 0
 
         if length == 0:
-            return ''
+            return b''
         else:
-            return '\n'.join(log.split('\n')[-int(length):])
+            return b'\n'.join(log.split(b'\n')[-int(length):])
 
     @messaging.expected_exceptions(exception.ConsoleTypeInvalid,
                                    exception.InstanceNotReady,

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -2648,11 +2648,11 @@ class ComputeTestCase(BaseTestCase):
     def test_rebuild_with_injected_files(self):
         # Ensure instance can be rebuilt with injected files.
         injected_files = [
-            ('/a/b/c', base64.b64encode('foobarbaz')),
+            (b'/a/b/c', base64.b64encode(b'foobarbaz')),
         ]
 
         self.decoded_files = [
-            ('/a/b/c', 'foobarbaz'),
+            (b'/a/b/c', b'foobarbaz'),
         ]
 
         def _spawn(context, instance, image_meta, injected_files,
@@ -3237,8 +3237,21 @@ class ComputeTestCase(BaseTestCase):
 
         output = self.compute.get_console_output(self.context,
                 instance=instance, tail_length=None)
-        self.assertEqual(output, 'FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE')
+        self.assertEqual(output, b'FAKE CONSOLE OUTPUT\nANOTHER\nLAST LINE')
         self.compute.terminate_instance(self.context, instance, [], [])
+
+    def test_console_output_bytes(self):
+        # Make sure we can get console output from instance.
+        instance = self._create_fake_instance_obj()
+
+        with mock.patch.object(self.compute,
+                               'get_console_output') as mock_console_output:
+            mock_console_output.return_value = b'Hello.'
+
+            output = self.compute.get_console_output(self.context,
+                    instance=instance, tail_length=None)
+            self.assertEqual(output, b'Hello.')
+            self.compute.terminate_instance(self.context, instance, [], [])
 
     def test_console_output_tail(self):
         # Make sure we can get console output from instance.
@@ -3248,7 +3261,7 @@ class ComputeTestCase(BaseTestCase):
 
         output = self.compute.get_console_output(self.context,
                 instance=instance, tail_length=2)
-        self.assertEqual(output, 'ANOTHER\nLAST LINE')
+        self.assertEqual(output, b'ANOTHER\nLAST LINE')
         self.compute.terminate_instance(self.context, instance, [], [])
 
     def test_console_output_not_implemented(self):
@@ -6036,8 +6049,12 @@ class ComputeTestCase(BaseTestCase):
     def test_add_instance_fault_with_remote_error(self):
         instance = self._create_fake_instance_obj()
         exc_info = None
+        raised_exc = None
 
         def fake_db_fault_create(ctxt, values):
+            global exc_info
+            global raised_exc
+
             self.assertIn('raise messaging.RemoteError', values['details'])
             del values['details']
 
@@ -6053,13 +6070,14 @@ class ComputeTestCase(BaseTestCase):
         try:
             raise messaging.RemoteError('test', 'My Test Message')
         except messaging.RemoteError as exc:
+            raised_exc = exc
             exc_info = sys.exc_info()
 
         self.stubs.Set(nova.db, 'instance_fault_create', fake_db_fault_create)
 
         ctxt = context.get_admin_context()
         compute_utils.add_instance_fault_from_exc(ctxt,
-            instance, exc, exc_info)
+            instance, raised_exc, exc_info)
 
     def test_add_instance_fault_user_error(self):
         instance = self._create_fake_instance_obj()
@@ -11434,8 +11452,8 @@ class EvacuateHostTestCase(BaseTestCase):
                           lambda: self._rebuild(on_shared_storage=True))
 
     def test_driver_does_not_support_recreate(self):
-        with utils.temporary_mutation(self.compute.driver.capabilities,
-                                      supports_recreate=False):
+        with mock.patch.dict(self.compute.driver.capabilities,
+                             supports_recreate=False):
             self.stubs.Set(self.compute.driver, 'instance_on_disk',
                            lambda x: True)
             self.assertRaises(exception.InstanceRecreateNotSupported,

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -1099,7 +1099,7 @@ class ExceptionHelper(object):
             try:
                 return func(*args, **kwargs)
             except messaging.ExpectedException as e:
-                raise (e.exc_info[1], None, e.exc_info[2])
+                six.reraise(*e.exc_info)
         return wrapper
 
 
@@ -1296,7 +1296,7 @@ def get_system_metadata_from_image(image_meta, flavor=None):
             if image_meta.get('disk_format') == 'vhd':
                 value = flavor['root_gb']
             else:
-                value = max(value, flavor['root_gb'])
+                value = max(value or 0, flavor['root_gb'])
 
         if value is None:
             continue


### PR DESCRIPTION
Commit Ibe5ecde51655334adafba12280a44d2ddd22c7ec introduced some
python 3.4 compatible changes that were not tested by gate-nova-python34.

Removes unit tests from tests-py3.txt blacklist that covers the changes
made in the mentioned commit.

Adds fixes in order for newly enabled unit tests to pass.

(cherry-picked from commit 0e52003a205bc791888d6355bec5ae8088f92687)

Partially implements blueprint: nova-python3-mitaka

Change-Id: Id1268b53e68edf375e852d33d028e2da57e69bad