### PR TITLE
Py3: fix serial console output

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -4462,7 +4462,7 @@ class ComputeManager(manager.Manager):
         if tail_length is not None:
             output = self._tail_log(output, tail_length)
 
-        return output.decode('utf-8', 'replace').encode('ascii', 'replace')
+        return output.decode('ascii', 'replace')
 
     def _tail_log(self, log, length):
         try:


### PR DESCRIPTION
The compute API expects the serial console output to be a string,
attempting to use a regex to remove some characters.

This will fail as we are returning a byte array.

Change-Id: I5d3097f1d30f3b3568a5421e0d68aaf0797c850a